### PR TITLE
Apply Generics in the Network Service Models

### DIFF
--- a/PlantApp.xcodeproj/project.pbxproj
+++ b/PlantApp.xcodeproj/project.pbxproj
@@ -56,9 +56,9 @@
 		B2DFADB02B8822CF00FB0B0A /* peacock_plant.usdz in Resources */ = {isa = PBXBuildFile; fileRef = B2DFADAF2B8822CE00FB0B0A /* peacock_plant.usdz */; };
 		B2DFADB22B88258300FB0B0A /* parlor_palm.usdz in Resources */ = {isa = PBXBuildFile; fileRef = B2DFADB12B88258300FB0B0A /* parlor_palm.usdz */; };
 		B2E566882BA10CCB0065B1C8 /* PlantService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E566872BA10CCB0065B1C8 /* PlantService.swift */; };
-		B2E5668A2BA116D50065B1C8 /* PlantCollectionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E566892BA116D50065B1C8 /* PlantCollectionResponse.swift */; };
+		B2E5668A2BA116D50065B1C8 /* CollectionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E566892BA116D50065B1C8 /* CollectionResponse.swift */; };
 		B2E5668D2BA119F70065B1C8 /* Plant.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E5668C2BA119F70065B1C8 /* Plant.swift */; };
-		B2E566902BA16E900065B1C8 /* PlantResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E5668F2BA16E900065B1C8 /* PlantResponse.swift */; };
+		B2E566902BA16E900065B1C8 /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E5668F2BA16E900065B1C8 /* Response.swift */; };
 		B2FFEEF82B7D200500886F87 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FFEEF72B7D200500886F87 /* Coordinator.swift */; };
 		B2FFEEFA2B7EB6DA00886F87 /* LuxMeasureCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FFEEF92B7EB6DA00886F87 /* LuxMeasureCoordinator.swift */; };
 		B2FFEEFD2B80546800886F87 /* ARPlaceBoxViewContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FFEEFC2B80546800886F87 /* ARPlaceBoxViewContainer.swift */; };
@@ -136,9 +136,9 @@
 		B2DFADAF2B8822CE00FB0B0A /* peacock_plant.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = peacock_plant.usdz; sourceTree = "<group>"; };
 		B2DFADB12B88258300FB0B0A /* parlor_palm.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = parlor_palm.usdz; sourceTree = "<group>"; };
 		B2E566872BA10CCB0065B1C8 /* PlantService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlantService.swift; sourceTree = "<group>"; };
-		B2E566892BA116D50065B1C8 /* PlantCollectionResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlantCollectionResponse.swift; sourceTree = "<group>"; };
+		B2E566892BA116D50065B1C8 /* CollectionResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionResponse.swift; sourceTree = "<group>"; };
 		B2E5668C2BA119F70065B1C8 /* Plant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plant.swift; sourceTree = "<group>"; };
-		B2E5668F2BA16E900065B1C8 /* PlantResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlantResponse.swift; sourceTree = "<group>"; };
+		B2E5668F2BA16E900065B1C8 /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
 		B2FFEEF72B7D200500886F87 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		B2FFEEF92B7EB6DA00886F87 /* LuxMeasureCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LuxMeasureCoordinator.swift; sourceTree = "<group>"; };
 		B2FFEEFC2B80546800886F87 /* ARPlaceBoxViewContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARPlaceBoxViewContainer.swift; sourceTree = "<group>"; };
@@ -378,8 +378,8 @@
 			isa = PBXGroup;
 			children = (
 				B2E5668C2BA119F70065B1C8 /* Plant.swift */,
-				B2E5668F2BA16E900065B1C8 /* PlantResponse.swift */,
-				B2E566892BA116D50065B1C8 /* PlantCollectionResponse.swift */,
+				B2E5668F2BA16E900065B1C8 /* Response.swift */,
+				B2E566892BA116D50065B1C8 /* CollectionResponse.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -551,7 +551,7 @@
 				B231091D2AFA0E6100D13F17 /* PrimaryButton.swift in Sources */,
 				B2D94BFD2B858B64002B38AB /* PlacePlantCoordinator.swift in Sources */,
 				B23108FC2AFA05D700D13F17 /* ContentView.swift in Sources */,
-				B2E566902BA16E900065B1C8 /* PlantResponse.swift in Sources */,
+				B2E566902BA16E900065B1C8 /* Response.swift in Sources */,
 				B23108F52AFA05D700D13F17 /* QuestionView.swift in Sources */,
 				B2D94BF92B856FE7002B38AB /* ARPlacePlantView.swift in Sources */,
 				B2D94BFB2B858019002B38AB /* ARPlacePlantViewContainer.swift in Sources */,
@@ -575,7 +575,7 @@
 				B231091A2AFA0E6100D13F17 /* SearchBar.swift in Sources */,
 				B23108F72AFA05D700D13F17 /* ARDetectView.swift in Sources */,
 				B23108C12AFA051300D13F17 /* ContentARView.swift in Sources */,
-				B2E5668A2BA116D50065B1C8 /* PlantCollectionResponse.swift in Sources */,
+				B2E5668A2BA116D50065B1C8 /* CollectionResponse.swift in Sources */,
 				B23108BF2AFA051300D13F17 /* AppDelegate.swift in Sources */,
 				B231096E2B0DD7EE00D13F17 /* ARPlaceBoxView.swift in Sources */,
 				B2E566882BA10CCB0065B1C8 /* PlantService.swift in Sources */,

--- a/PlantApp.xcodeproj/project.pbxproj
+++ b/PlantApp.xcodeproj/project.pbxproj
@@ -55,7 +55,7 @@
 		B2DFADAE2B88200600FB0B0A /* marginata.usdz in Resources */ = {isa = PBXBuildFile; fileRef = B2DFADAD2B88200600FB0B0A /* marginata.usdz */; };
 		B2DFADB02B8822CF00FB0B0A /* peacock_plant.usdz in Resources */ = {isa = PBXBuildFile; fileRef = B2DFADAF2B8822CE00FB0B0A /* peacock_plant.usdz */; };
 		B2DFADB22B88258300FB0B0A /* parlor_palm.usdz in Resources */ = {isa = PBXBuildFile; fileRef = B2DFADB12B88258300FB0B0A /* parlor_palm.usdz */; };
-		B2E566882BA10CCB0065B1C8 /* PlantService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E566872BA10CCB0065B1C8 /* PlantService.swift */; };
+		B2E566882BA10CCB0065B1C8 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E566872BA10CCB0065B1C8 /* NetworkManager.swift */; };
 		B2E5668A2BA116D50065B1C8 /* CollectionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E566892BA116D50065B1C8 /* CollectionResponse.swift */; };
 		B2E5668D2BA119F70065B1C8 /* Plant.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E5668C2BA119F70065B1C8 /* Plant.swift */; };
 		B2E566902BA16E900065B1C8 /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E5668F2BA16E900065B1C8 /* Response.swift */; };
@@ -135,7 +135,7 @@
 		B2DFADAD2B88200600FB0B0A /* marginata.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = marginata.usdz; sourceTree = "<group>"; };
 		B2DFADAF2B8822CE00FB0B0A /* peacock_plant.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = peacock_plant.usdz; sourceTree = "<group>"; };
 		B2DFADB12B88258300FB0B0A /* parlor_palm.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = parlor_palm.usdz; sourceTree = "<group>"; };
-		B2E566872BA10CCB0065B1C8 /* PlantService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlantService.swift; sourceTree = "<group>"; };
+		B2E566872BA10CCB0065B1C8 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		B2E566892BA116D50065B1C8 /* CollectionResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionResponse.swift; sourceTree = "<group>"; };
 		B2E5668C2BA119F70065B1C8 /* Plant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plant.swift; sourceTree = "<group>"; };
 		B2E5668F2BA16E900065B1C8 /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
@@ -369,7 +369,7 @@
 			isa = PBXGroup;
 			children = (
 				B2E5668E2BA15A3F0065B1C8 /* Models */,
-				B2E566872BA10CCB0065B1C8 /* PlantService.swift */,
+				B2E566872BA10CCB0065B1C8 /* NetworkManager.swift */,
 			);
 			path = NetworkService;
 			sourceTree = "<group>";
@@ -578,7 +578,7 @@
 				B2E5668A2BA116D50065B1C8 /* CollectionResponse.swift in Sources */,
 				B23108BF2AFA051300D13F17 /* AppDelegate.swift in Sources */,
 				B231096E2B0DD7EE00D13F17 /* ARPlaceBoxView.swift in Sources */,
-				B2E566882BA10CCB0065B1C8 /* PlantService.swift in Sources */,
+				B2E566882BA10CCB0065B1C8 /* NetworkManager.swift in Sources */,
 				B23108F62AFA05D700D13F17 /* AccountView.swift in Sources */,
 				B23108FA2AFA05D700D13F17 /* ProductDetailView.swift in Sources */,
 				B23109722B0DD91500D13F17 /* ARView+Extensions.swift in Sources */,

--- a/PlantApp.xcodeproj/project.pbxproj
+++ b/PlantApp.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		B23109722B0DD91500D13F17 /* ARView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B23109712B0DD91500D13F17 /* ARView+Extensions.swift */; };
 		B2B5EA052BA4D6430078D804 /* ScrollSectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B5EA042BA4D6430078D804 /* ScrollSectionViewModel.swift */; };
 		B2B5EA092BA4F4E30078D804 /* ScrollSectionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B5EA082BA4F4E30078D804 /* ScrollSectionViewModelTests.swift */; };
+		B2B5EA0C2BAA69880078D804 /* PlantService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B5EA0B2BAA69880078D804 /* PlantService.swift */; };
 		B2D94BF42B856EC6002B38AB /* swiss_cheese.usdz in Resources */ = {isa = PBXBuildFile; fileRef = B2D94BF22B856EC6002B38AB /* swiss_cheese.usdz */; };
 		B2D94BF92B856FE7002B38AB /* ARPlacePlantView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D94BF82B856FE7002B38AB /* ARPlacePlantView.swift */; };
 		B2D94BFB2B858019002B38AB /* ARPlacePlantViewContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D94BFA2B858019002B38AB /* ARPlacePlantViewContainer.swift */; };
@@ -122,6 +123,7 @@
 		B23109712B0DD91500D13F17 /* ARView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ARView+Extensions.swift"; sourceTree = "<group>"; };
 		B2B5EA042BA4D6430078D804 /* ScrollSectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollSectionViewModel.swift; sourceTree = "<group>"; };
 		B2B5EA082BA4F4E30078D804 /* ScrollSectionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollSectionViewModelTests.swift; sourceTree = "<group>"; };
+		B2B5EA0B2BAA69880078D804 /* PlantService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlantService.swift; sourceTree = "<group>"; };
 		B2D94BF22B856EC6002B38AB /* swiss_cheese.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = swiss_cheese.usdz; sourceTree = "<group>"; };
 		B2D94BF82B856FE7002B38AB /* ARPlacePlantView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARPlacePlantView.swift; sourceTree = "<group>"; };
 		B2D94BFA2B858019002B38AB /* ARPlacePlantViewContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARPlacePlantViewContainer.swift; sourceTree = "<group>"; };
@@ -370,6 +372,7 @@
 			children = (
 				B2E5668E2BA15A3F0065B1C8 /* Models */,
 				B2E566872BA10CCB0065B1C8 /* NetworkManager.swift */,
+				B2B5EA0B2BAA69880078D804 /* PlantService.swift */,
 			);
 			path = NetworkService;
 			sourceTree = "<group>";
@@ -559,6 +562,7 @@
 				B2FFEEFA2B7EB6DA00886F87 /* LuxMeasureCoordinator.swift in Sources */,
 				B23108F42AFA05D700D13F17 /* OnboardingView.swift in Sources */,
 				B23109082AFA07ED00D13F17 /* QuestionModel.swift in Sources */,
+				B2B5EA0C2BAA69880078D804 /* PlantService.swift in Sources */,
 				B2B5EA052BA4D6430078D804 /* ScrollSectionViewModel.swift in Sources */,
 				B23109242AFA171F00D13F17 /* Iterator.swift in Sources */,
 				B231091C2AFA0E6100D13F17 /* ScrollSection.swift in Sources */,

--- a/PlantApp/Components/Scroll Section/ScrollSectionViewModel.swift
+++ b/PlantApp/Components/Scroll Section/ScrollSectionViewModel.swift
@@ -40,6 +40,7 @@ import SwiftUI
         isLoadingPlantList = true
         do {
             plantList = try await plantService.getPlants()
+            // try await print(plantService.getPlant(withId: "100001"))
         } catch URLError.badURL {
             showingError = true
             alertBodyString += " bad URL"

--- a/PlantApp/Components/Scroll Section/ScrollSectionViewModel.swift
+++ b/PlantApp/Components/Scroll Section/ScrollSectionViewModel.swift
@@ -40,7 +40,6 @@ import SwiftUI
         isLoadingPlantList = true
         do {
             plantList = try await plantService.getPlants()
-            // try await print(plantService.getPlant(withId: "100001"))
         } catch URLError.badURL {
             showingError = true
             alertBodyString += " bad URL"

--- a/PlantApp/NetworkService/Models/CollectionResponse.swift
+++ b/PlantApp/NetworkService/Models/CollectionResponse.swift
@@ -1,5 +1,5 @@
 //
-//  PlantCollectionResponse.swift
+//  CollectionResponse.swift
 //  PlantApp
 //
 //  Created by Aeliana Shen on 3/12/24.
@@ -7,12 +7,12 @@
 
 import Foundation
 
-struct PlantCollectionResponse: Codable {
+struct CollectionResponse<Model: Codable>: Codable {
     let count: Int
-    let plants: [Plant]
+    let items: [Model]
 
     enum CodingKeys: String, CodingKey {
         case count = "Count"
-        case plants = "Items"
+        case items = "Items"
     }
 }

--- a/PlantApp/NetworkService/Models/Response.swift
+++ b/PlantApp/NetworkService/Models/Response.swift
@@ -1,5 +1,5 @@
 //
-//  PlantResponse.swift
+//  Response.swift
 //  PlantApp
 //
 //  Created by Aeliana Shen on 3/12/24.
@@ -7,10 +7,10 @@
 
 import Foundation
 
-struct PlantResponse: Codable {
-    let plant: Plant
+struct Response<Model: Codable>: Codable {
+    let item: Model
 
     enum CodingKeys: String, CodingKey {
-        case plant = "Item"
+        case item = "Item"
     }
 }

--- a/PlantApp/NetworkService/NetworkManager.swift
+++ b/PlantApp/NetworkService/NetworkManager.swift
@@ -1,5 +1,5 @@
 //
-//  PlantService.swift
+//  NetworkManage.swift
 //  PlantApp
 //
 //  Created by Aeliana Shen on 3/12/24.

--- a/PlantApp/NetworkService/NetworkManager.swift
+++ b/PlantApp/NetworkService/NetworkManager.swift
@@ -7,11 +7,6 @@
 
 import Foundation
 
-protocol PlantServiceProtocol {
-    func getPlants() async throws -> [Plant]
-    func getPlant(withId plantId: String) async throws -> Plant
-}
-
 class NetworkManager {
     private let baseURL = "https://p6ib01la4m.execute-api.us-west-2.amazonaws.com/prod/"
     
@@ -41,17 +36,5 @@ class NetworkManager {
         } catch {
             throw URLError(.cannotDecodeContentData)
         }
-    }
-}
-
-class PlantService: PlantServiceProtocol {
-    private let networkManager = NetworkManager()
-    
-    func getPlants() async throws -> [Plant] {
-        try await networkManager.getCollection(endpoint: "defproducts")
-    }
-    
-    func getPlant(withId plantId: String) async throws -> Plant {
-        try await networkManager.get(endpoint: "product?productId=\(plantId)")
     }
 }

--- a/PlantApp/NetworkService/PlantService.swift
+++ b/PlantApp/NetworkService/PlantService.swift
@@ -9,6 +9,7 @@ import Foundation
 
 protocol PlantServiceProtocol {
     func getPlants() async throws -> [Plant]
+    func getPlant(withId plantId: String) async throws -> Plant
 }
 
 class NetworkManager {
@@ -17,7 +18,7 @@ class NetworkManager {
     func getCollection<Model: Codable>(endpoint: String) async throws -> [Model] {
         guard let url = URL(string: "\(baseURL)\(endpoint)") else { throw URLError(.badURL) }
         
-        let (data, response) = try await URLSession.shared.data(from: url)
+        let (data, _) = try await URLSession.shared.data(from: url)
         
         do {
             let decoder = JSONDecoder()
@@ -31,7 +32,7 @@ class NetworkManager {
     func get<Model: Codable>(endpoint: String) async throws -> Model {
         guard let url = URL(string: "\(baseURL)\(endpoint)") else { throw URLError(.badURL) }
         
-        let (data, response) = try await URLSession.shared.data(from: url)
+        let (data, _) = try await URLSession.shared.data(from: url)
         
         do {
             let decoder = JSONDecoder()

--- a/PlantApp/NetworkService/PlantService.swift
+++ b/PlantApp/NetworkService/PlantService.swift
@@ -52,6 +52,6 @@ class PlantService: PlantServiceProtocol {
     }
     
     func getPlant(withId plantId: String) async throws -> Plant {
-        try await networkManager.get(endpoint: "products?productId\(plantId)")
+        try await networkManager.get(endpoint: "product?productId=\(plantId)")
     }
 }

--- a/PlantApp/NetworkService/PlantService.swift
+++ b/PlantApp/NetworkService/PlantService.swift
@@ -1,0 +1,25 @@
+//
+//  PlantService.swift
+//  PlantApp
+//
+//  Created by Aeliana Shen on 3/19/24.
+//
+
+import Foundation
+
+protocol PlantServiceProtocol {
+    func getPlants() async throws -> [Plant]
+    func getPlant(withId plantId: String) async throws -> Plant
+}
+
+class PlantService: PlantServiceProtocol {
+    private let networkManager = NetworkManager()
+    
+    func getPlants() async throws -> [Plant] {
+        try await networkManager.getCollection(endpoint: "defproducts")
+    }
+    
+    func getPlant(withId plantId: String) async throws -> Plant {
+        try await networkManager.get(endpoint: "product?productId=\(plantId)")
+    }
+}

--- a/PlantAppTests/Mocks/MockPlantService.swift
+++ b/PlantAppTests/Mocks/MockPlantService.swift
@@ -12,10 +12,18 @@ class MockSuccessPlantService: PlantServiceProtocol {
     func getPlants() async throws -> [Plant] {
         return Plant.localPlantList
     }
+    
+    func getPlant(withId plantId: String) async throws -> Plant {
+        return Plant.localPlantList[0]
+    }
 }
 
 class MockBadUrlFailurePlantService: PlantServiceProtocol {
     func getPlants() async throws -> [Plant] {
+        throw URLError(.badURL)
+    }
+    
+    func getPlant(withId plantId: String) async throws -> Plant {
         throw URLError(.badURL)
     }
 }
@@ -24,16 +32,28 @@ class MockBadServerResponseFailurePlantService: PlantServiceProtocol {
     func getPlants() async throws -> [Plant] {
         throw URLError(.badServerResponse)
     }
+    
+    func getPlant(withId plantId: String) async throws -> Plant {
+        throw URLError(.badServerResponse)
+    }
 }
 
 class MockCannotDecodeContentDataFailurePlantService: PlantServiceProtocol {
     func getPlants() async throws -> [Plant] {
         throw URLError(.cannotDecodeContentData)
     }
+    
+    func getPlant(withId plantId: String) async throws -> Plant {
+        throw URLError(.cannotDecodeContentData)
+    }
 }
 
 class MockGeneralFailurePlantService: PlantServiceProtocol {
     func getPlants() async throws -> [Plant] {
+        throw URLError(.networkConnectionLost)
+    }
+    
+    func getPlant(withId plantId: String) async throws -> Plant {
         throw URLError(.networkConnectionLost)
     }
 }


### PR DESCRIPTION
- applied Generics
- separated the base URL and endpoint strings.
- add the NetworkManager class that includes get functions
- able to call the get functions inside the PlantService